### PR TITLE
refactor: add details of table style and always show total of pieces

### DIFF
--- a/src/modules/OrderTable/components/TableBody/TableBody.tsx
+++ b/src/modules/OrderTable/components/TableBody/TableBody.tsx
@@ -52,7 +52,9 @@ export function TableBody({ list, clothingList, isPrinted, clothingsInPrint }: P
         {list.map((props) => (
           <tr key={`${props.id}_checkbox`}>
             <td className={style.tableCell}>
+              <label className={style.ghostLabel} htmlFor={`checkbox_${props.id}`} />
               <input
+                id={`checkbox_${props.id}`}
                 type="checkbox"
                 onChange={e => (
                   e.target.checked 

--- a/src/modules/OrderTable/components/TableBody/style.module.css
+++ b/src/modules/OrderTable/components/TableBody/style.module.css
@@ -1,4 +1,13 @@
 .tableCell {
   text-align: center;
   padding: .2rem;
+  position: relative;
+}
+
+.ghostLabel {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  left: 0;
+  top: 0;
 }

--- a/src/modules/OrderTable/components/TableHead.tsx
+++ b/src/modules/OrderTable/components/TableHead.tsx
@@ -27,16 +27,12 @@ export function TableHead({ clothings, isCycling, isPrinted, list, clothingsInPr
   }, [list]);
   return (
     <thead>
-      {isPrinted ? (
-        <tr>
-          <td colSpan={14} className="text-center p-2">
-            {t('MAIN_TITLE')} -{' '}
-            {`${t('CONTAINS_N_UNITS')} ${pieces}`}
-            <strong>
-            </strong>
-          </td>
-        </tr>
-      ) : null}
+      <tr className='totalPieces'>
+        <td colSpan={14} className="text-center p-2">
+          {t('MAIN_TITLE')} -{' '}
+          {`${t('CONTAINS_N_UNITS')} ${pieces}`}
+        </td>
+      </tr>
       <tr className="text-center">
         <th style={{ maxWidth: '50px' }}>
           <FontAwesomeIcon icon={faHandHoldingUsd} />

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -94,7 +94,7 @@ button {
   
   table,
   td, th {
-    border: 1px solid #000;
+    border: 1px solid #616160;
     border-collapse: collapse;
   }
   
@@ -109,16 +109,27 @@ button {
   input[type="checkbox"] {
     transition: none !important;
   }
-  thead {
+  thead > tr {
+    background: #e6e3e3;
+  }
+  thead > .totalPieces {
     background: #fff;
   }
-  tr:hover{
+  tbody > tr:hover{
     background: #bbb;
+  }
+
+  tbody td {
+    padding: .3rem;
   }
   
   td:hover {
     background: #211;
     color: #fff;
+  }
+
+  tbody tr:nth-child(even) {
+    background-color: #ededed;
   }
 }
   


### PR DESCRIPTION
- [x] Colocar as linhas cinza claro semelhante ao antigo.
- [x] Usar mesmo padrão de tamanho antigo
- [x] Colocar total de peças para cada sublista no front (semelhante antigo)
